### PR TITLE
Add globalSettings param to the streaming function to set global Juice settings

### DIFF
--- a/src/gulp-juice.js
+++ b/src/gulp-juice.js
@@ -21,8 +21,15 @@ function injectCSS(html, css) {
 
 var PLUGIN_NAME = 'gulp-plugin-concat';
 
-function gulpJuiceStream(conf) {
+function gulpJuiceStream(conf, globalSettings) {
+	globalSettings = globalSettings || {};
 	conf = conf || {};
+
+	// Looping through the globalSettings param to set global juice settings
+	_.forEach(globalSettings, function(value, key){
+		juice[key] = value;
+	});
+
 	// Creating a stream through which each file will pass
 
 	var htmlFiles = [];


### PR DESCRIPTION
In this way, calling from the gulpfile something like

<pre>gulp.src('./*.html')
        .pipe(juice(
            {
                applyWidthAttributes : true,
                applyAttributesTableElements : true,
                removeStyleTags: false,
                extraCss : ""
            },
            {
                styleToAttribute : {
                    'border-collapse' : 'sbadam'
                }
            }
        ))
        .pipe(gulp.dest('./'));</pre>


the user will be able to set the globals variables (see [https://www.npmjs.com/package/juice#global-settings](https://www.npmjs.com/package/juice#global-settings))

Cheers
